### PR TITLE
4-missing-namespace-in-function-exists-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added missing namespace `Folded` to `function_exists` statements.
+
 ## [0.1.1] 2020-09-22
 
 ### Fixed

--- a/src/addAlertLog.php
+++ b/src/addAlertLog.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addAlertLog")) {
+if (!function_exists("Folded\addAlertLog")) {
     /**
      * Logs an alert.
      *

--- a/src/addCriticalLog.php
+++ b/src/addCriticalLog.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addCriticalLog")) {
+if (!function_exists("Folded\addCriticalLog")) {
     /**
      * Logs a critical message.
      *

--- a/src/addDebugLog.php
+++ b/src/addDebugLog.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addDebugLog")) {
+if (!function_exists("Folded\addDebugLog")) {
     /**
      * Logs a debug message.
      *

--- a/src/addEmergencyLog.php
+++ b/src/addEmergencyLog.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addEmergencyLog")) {
+if (!function_exists("Folded\addEmergencyLog")) {
     /**
      * Logs an emergency message.
      *

--- a/src/addErrorLog.php
+++ b/src/addErrorLog.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addErrorLog")) {
+if (!function_exists("Folded\addErrorLog")) {
     /**
      * Logs an error message.
      *

--- a/src/addInfoLog.php
+++ b/src/addInfoLog.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addInfoLog")) {
+if (!function_exists("Folded\addInfoLog")) {
     /**
      * Logs an info message.
      *

--- a/src/addLog.php
+++ b/src/addLog.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addLog")) {
+if (!function_exists("Folded\addLog")) {
     /**
      * Logs an message of the desired severity.
      *

--- a/src/addLogger.php
+++ b/src/addLogger.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addLogger")) {
+if (!function_exists("Folded\addLogger")) {
     /**
      * Registers a new logger.
      * If the last two parameters are specified, will also triggers an addLoggerChannel method.

--- a/src/addLoggerChannel.php
+++ b/src/addLoggerChannel.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addLoggerChannel")) {
+if (!function_exists("Folded\addLoggerChannel")) {
     /**
      * Add a channel to write by the logger.
      *

--- a/src/addNoticeLog.php
+++ b/src/addNoticeLog.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addNoticeLog")) {
+if (!function_exists("Folded\addNoticeLog")) {
     /**
      * Logs a notice.
      *

--- a/src/addWarningLog.php
+++ b/src/addWarningLog.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("addWarningLog")) {
+if (!function_exists("Folded\addWarningLog")) {
     /**
      * Logs a warning.
      *


### PR DESCRIPTION
## Added

None.

## Fixed

- Bug when namespace `Folded` was missing from `function_exists` statements.

## Breaking

None.